### PR TITLE
Fix description for AssociationMatcher

### DIFF
--- a/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
@@ -19,6 +19,12 @@ module RSpecJSONAPISerializer
                      .has_key?(expected)
       end
 
+      def description
+        description = "#{association_message} #{expected}"
+
+        [description, submatchers.map(&:description)].flatten.join(' ')
+      end
+
       def main_failure_message
         [expected_message, actual_message].compact.join(", ")
       end
@@ -36,7 +42,7 @@ module RSpecJSONAPISerializer
       end
 
       def association_message
-        relationship_matcher.to_s.split('_')
+        relationship_matcher.to_s.split("_").join(" ")
       end
 
       def actual

--- a/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def description
+        association_matcher.description
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def description
+        association_matcher.description
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
@@ -13,6 +13,10 @@ module RSpecJSONAPISerializer
         association_matcher.matches?(serializer_instance)
       end
 
+      def description
+        association_matcher.description
+      end
+
       def main_failure_message
         association_matcher.main_failure_message
       end


### PR DESCRIPTION
RSpec is giving a bunch of warnings when these matchers are used without a description.

```
When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again
```