### PR TITLE
Fix description for attribute matchers

### DIFF
--- a/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
@@ -25,7 +25,7 @@ module RSpecJSONAPISerializer
         [description, submatchers.map(&:description)].flatten.join(' ')
       end
 
-      def main_failure_message
+      def failure_message
         [expected_message, actual_message].compact.join(", ")
       end
 

--- a/lib/rspec_jsonapi_serializer/matchers/base.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/base.rb
@@ -13,26 +13,16 @@ module RSpecJSONAPISerializer
       end
 
       def failure_message
-        ([main_failure_message] + submatcher_failure_messages).compact.join("\n")
+        raise NotImplementedError
       end
 
       def failure_message_when_negated
-        ([main_failure_message_when_negated] + submatcher_failure_messages_when_negated)
-          .compact
-          .join("\n")
+        raise NotImplementedError
       end
 
       protected
 
       attr_reader :expected, :serializer_instance, :submatchers
-
-      def main_failure_message
-        raise NotImplementedError
-      end
-
-      def main_failure_message_when_negated
-        raise NotImplementedError
-      end
 
       def add_submatcher(submatcher)
         submatchers << submatcher
@@ -48,16 +38,6 @@ module RSpecJSONAPISerializer
 
       def serializer_name
         serializer_instance.class.name
-      end
-
-      private
-
-      def submatcher_failure_messages
-        failing_submatchers.map(&:failure_message)
-      end
-
-      def submatcher_failure_messages_when_negated
-        failing_submatchers.map(&:failure_message_when_negated)
       end
 
       def failing_submatchers

--- a/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/belong_to_matcher.rb
@@ -17,8 +17,8 @@ module RSpecJSONAPISerializer
         association_matcher.description
       end
 
-      def main_failure_message
-        association_matcher.main_failure_message
+      def failure_message
+        association_matcher.failure_message
       end
 
       private

--- a/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
@@ -24,11 +24,25 @@ module RSpecJSONAPISerializer
         self
       end
 
+      def description
+        description = "have attributed #{expected}"
+
+        [description, submatchers.map(&:description)].flatten.join(' ')
+      end
+
       def main_failure_message
-        "expected #{serializer_name} to have attribute #{expected}." unless has_attribute?
+        "expected #{expectation}."
+      end
+
+      def main_failure_message_when_negated
+        "Did not expect #{expectation}."
       end
 
       private
+
+      def expectation
+        "#{serializer_name} to have attribute #{expected}"
+      end
 
       def attributes
         @attributes ||= serializer_instance.class.try(:attributes_to_serialize) || {}

--- a/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
@@ -19,9 +19,7 @@ module RSpecJSONAPISerializer
       end
 
       def as_nil
-        add_submatcher HaveAttributeMatchers::AsMatcher.new(expected, nil)
-
-        self
+        as(nil)
       end
 
       def description
@@ -30,18 +28,24 @@ module RSpecJSONAPISerializer
         [description, submatchers.map(&:description)].flatten.join(' ')
       end
 
-      def main_failure_message
-        "expected #{expectation}."
+      def failure_message
+        "Expected #{expectation}."
       end
 
-      def main_failure_message_when_negated
+      def failure_message_when_negated
         "Did not expect #{expectation}."
       end
 
       private
 
       def expectation
-        "#{serializer_name} to have attribute #{expected}"
+        expectation = "#{serializer_name} to have attribute #{expected}"
+
+        submatchers_expectations = failing_submatchers.map do |submatcher|
+          "(#{submatcher.expectation})"
+        end.compact.join(", ")
+
+        [expectation, submatchers_expectations].reject(&:nil?).reject(&:empty?).join(" ")
       end
 
       def attributes

--- a/lib/rspec_jsonapi_serializer/matchers/have_attribute_matchers/as_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_attribute_matchers/as_matcher.rb
@@ -18,20 +18,30 @@ module RSpecJSONAPISerializer
           actual == expected
         end
 
-        def failure_message
-          [expected_message, actual_message].compact.join(", ")
+        def description
+          "as #{expected_to_string}"
+        end
+
+        def expectation
+          [ "as #{expected_to_string}", actual_message ].compact.join(", ")
         end
 
         private
 
         attr_reader :attribute
 
-        def expected_message
-          "expected #{serializer_instance.class.name} to serialize #{attribute} as #{expected}"
+        def expected_to_string
+          value_to_string(expected)
         end
 
         def actual_message
-          "got #{actual.nil? ? 'nil' : actual} instead" if attributes.has_key?(attribute)
+          "got #{value_to_string(actual)} instead" if attributes.has_key?(attribute)
+        end
+
+        def value_to_string(value)
+          return 'nil' if value.nil?
+
+          value.to_s
         end
 
         def actual

--- a/lib/rspec_jsonapi_serializer/matchers/have_id_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_id_matcher.rb
@@ -11,7 +11,7 @@ module RSpecJSONAPISerializer
         actual == expected
       end
 
-      def main_failure_message
+      def failure_message
         "expected that #{serializer_name} to have id :#{expected}, got :#{actual} instead"
       end
 

--- a/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
@@ -24,7 +24,7 @@ module RSpecJSONAPISerializer
         self
       end
 
-      def main_failure_message
+      def failure_message
         "expected #{serializer_name} to have link #{expected}." unless has_link?
       end
 

--- a/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_many_matcher.rb
@@ -17,8 +17,8 @@ module RSpecJSONAPISerializer
         association_matcher.description
       end
 
-      def main_failure_message
-        association_matcher.main_failure_message
+      def failure_message
+        association_matcher.failure_message
       end
 
       private

--- a/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
@@ -24,7 +24,7 @@ module RSpecJSONAPISerializer
         self
       end
 
-      def main_failure_message
+      def failure_message
         "expected #{serializer_name} to serialize meta #{expected}." unless has_meta?
       end
 

--- a/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_one_matcher.rb
@@ -17,8 +17,8 @@ module RSpecJSONAPISerializer
         association_matcher.description
       end
 
-      def main_failure_message
-        association_matcher.main_failure_message
+      def failure_message
+        association_matcher.failure_message
       end
 
       private

--- a/lib/rspec_jsonapi_serializer/matchers/have_type_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_type_matcher.rb
@@ -11,7 +11,7 @@ module RSpecJSONAPISerializer
         actual == expected
       end
 
-      def main_failure_message
+      def failure_message
         "expected that #{serializer_name} to have type :#{expected}, got :#{actual} instead"
       end
 


### PR DESCRIPTION
This PR will suppress the RSpec warnings for attribute matchers being used without a description.