### PR TITLE
Fix description for link matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add default description for have_attribute matcher and submatchers
+- Add default description for have_link matcher and submatchers
+
 ## [1.0.0] - 2021-04-10
 
 - Initial release

--- a/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_attribute_matcher.rb
@@ -23,7 +23,7 @@ module RSpecJSONAPISerializer
       end
 
       def description
-        description = "have attributed #{expected}"
+        description = "have attribute #{expected}"
 
         [description, submatchers.map(&:description)].flatten.join(' ')
       end

--- a/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
@@ -39,7 +39,13 @@ module RSpecJSONAPISerializer
       private
 
       def expectation
-        "#{serializer_name} to have link #{expected}"
+        expectation = "#{serializer_name} to have link #{expected}"
+
+        submatchers_expectations = failing_submatchers.map do |submatcher|
+          "(#{submatcher.expectation})"
+        end.compact.join(", ")
+
+        [expectation, submatchers_expectations].reject(&:nil?).reject(&:empty?).join(" ")
       end
 
       def has_link?

--- a/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_link_matcher.rb
@@ -19,16 +19,28 @@ module RSpecJSONAPISerializer
       end
 
       def as_nil
-        add_submatcher HaveLinkMatchers::AsMatcher.new(expected, nil)
+        as(nil)
+      end
 
-        self
+      def description
+        description = "have link #{expected}"
+
+        [description, submatchers.map(&:description)].flatten.join(' ')
       end
 
       def failure_message
-        "expected #{serializer_name} to have link #{expected}." unless has_link?
+        "Expected #{expectation}."
+      end
+
+      def failure_message_when_negated
+        "Did not expect #{expectation}."
       end
 
       private
+
+      def expectation
+        "#{serializer_name} to have link #{expected}"
+      end
 
       def has_link?
         links.has_key?(expected)

--- a/lib/rspec_jsonapi_serializer/matchers/have_link_matchers/as_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_link_matchers/as_matcher.rb
@@ -18,20 +18,30 @@ module RSpecJSONAPISerializer
           actual == expected
         end
 
-        def failure_message
-          [expected_message, actual_message].compact.join(", ")
+        def description
+          "as #{expected_to_string}"
+        end
+
+        def expectation
+          [ "as #{expected_to_string}", actual_message ].compact.join(", ")
         end
 
         private
 
         attr_reader :link
 
-        def expected_message
-          "expected #{serializer_instance.class.name} to serialize link #{link} as #{expected}"
+        def expected_to_string
+          value_to_string(expected)
         end
 
         def actual_message
-          "got #{actual.nil? ? 'nil' : actual} instead" if links.has_key?(link)
+          "got #{value_to_string(actual)} instead" if links.has_key?(link)
+        end
+
+        def value_to_string(value)
+          return 'nil' if value.nil?
+
+          value.to_s
         end
 
         def actual


### PR DESCRIPTION
This PR will suppress the RSpec warnings for link matchers being used without a description.