### PR TITLE
Fix description for meta matchers

### DIFF
--- a/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
@@ -39,7 +39,13 @@ module RSpecJSONAPISerializer
       private
 
       def expectation
-        "#{serializer_name} to serialize meta #{expected}"
+        expectation = "#{serializer_name} to serialize meta #{expected}"
+
+        submatchers_expectations = failing_submatchers.map do |submatcher|
+          "(#{submatcher.expectation})"
+        end.compact.join(", ")
+
+        [expectation, submatchers_expectations].reject(&:nil?).reject(&:empty?).join(" ")
       end
 
       def metas

--- a/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_meta_matcher.rb
@@ -19,16 +19,28 @@ module RSpecJSONAPISerializer
       end
 
       def as_nil
-        add_submatcher HaveMetaMatchers::AsMatcher.new(expected, nil)
+        as(nil)
+      end
 
-        self
+      def description
+        description = "serialize meta #{expected}"
+
+        [description, submatchers.map(&:description)].flatten.join(' ')
       end
 
       def failure_message
-        "expected #{serializer_name} to serialize meta #{expected}." unless has_meta?
+        "Expected #{expectation}."
+      end
+
+      def failure_message_when_negated
+        "Did not expect #{expectation}."
       end
 
       private
+
+      def expectation
+        "#{serializer_name} to serialize meta #{expected}"
+      end
 
       def metas
         @metas ||= serializable_hash.dig(:data, :meta) || {}

--- a/lib/rspec_jsonapi_serializer/matchers/have_meta_matchers/as_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/have_meta_matchers/as_matcher.rb
@@ -18,21 +18,32 @@ module RSpecJSONAPISerializer
           actual == expected
         end
 
-        def failure_message
-          [expected_message, actual_message].compact.join(", ")
+        def description
+          "as #{expected_to_string}"
+        end
+
+        def expectation
+          [ "as #{expected_to_string}", actual_message ].compact.join(", ")
         end
 
         private
 
         attr_reader :meta
 
-        def expected_message
-          "expected #{serializer_instance.class.name} to serialize meta #{meta} as #{expected}"
+        def expected_to_string
+          value_to_string(expected)
         end
 
         def actual_message
           "got #{actual.nil? ? 'nil' : actual} instead" if metas.has_key?(meta)
         end
+
+        def value_to_string(value)
+          return 'nil' if value.nil?
+
+          value.to_s
+        end
+
 
         def actual
           metas[meta]


### PR DESCRIPTION
This PR will suppress the RSpec warnings for meta matchers being used without a description.