### PR TITLE
Add descriptions for relationship serializer submatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add default description for relationship serializer submatcher
+
 ## [1.1.0] - 2021-04-15
 
 - Add `.serializer` submatcher for relationship matchers (`belong_to`, `have_one` and `have_many`)

--- a/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matcher.rb
@@ -33,15 +33,25 @@ module RSpecJSONAPISerializer
       end
 
       def failure_message
-        [expected_message, actual_message].compact.join(", ")
+        "Expected #{expectation}"
+      end
+
+      def failure_message_when_negated
+        "Did not expect #{expectation}"
       end
 
       private
 
       attr_reader :relationship_matcher, :relationship_type
 
-      def expected_message
-        "expected #{serializer_name} to #{association_message} #{expected}"
+      def expectation
+        expectation = "#{serializer_name} to #{association_message} #{expected}"
+
+        submatchers_expectations = failing_submatchers.map do |submatcher|
+          "(#{submatcher.expectation})"
+        end.compact.join(", ")
+
+        [expectation, submatchers_expectations].reject(&:nil?).reject(&:empty?).join(" ")
       end
 
       def relationship_matches?

--- a/lib/rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matchers/serializer_matcher.rb
@@ -18,17 +18,17 @@ module RSpecJSONAPISerializer
           actual == expected
         end
 
-        def main_failure_message
-          [expected_message, actual_message].compact.join(", ")
+        def description
+          "with serializer #{expected}"
+        end
+
+        def expectation
+          [ "with serializer #{expected}", actual_message ].compact.join(", ")
         end
 
         private
 
         attr_reader :relationship_target
-
-        def expected_message
-          "expected #{serializer_name} to use #{expected} as serializer for #{relationship_target}"
-        end
 
         def actual_message
           actual ? "got #{actual} instead" : nil


### PR DESCRIPTION
This PR will suppress the RSpec warnings for relationship serializer submatchers being used without a description.