### PR TITLE
Add descriptions for relationship id_method_name submatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add default description for relationship id_method_name submatcher
+
 ## [1.2.0] - 2021-05-26
 
 - Add `.id_method_name` submatcher for relationship matchers (`belong_to`, `have_one` and `have_many`)

--- a/lib/rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher.rb
+++ b/lib/rspec_jsonapi_serializer/matchers/association_matchers/id_method_name_matcher.rb
@@ -9,7 +9,7 @@ module RSpecJSONAPISerializer
         def initialize(value, relationship_target)
           super(value)
 
-          @relationship_target  = relationship_target
+          @relationship_target = relationship_target
         end
 
         def matches?(serializer_instance)
@@ -18,17 +18,17 @@ module RSpecJSONAPISerializer
           actual == expected
         end
 
-        def main_failure_message
-          [expected_message, actual_message].compact.join(", ")
+        def description
+          "with id method name #{expected}"
+        end
+
+        def expectation
+          [ "with id method name #{expected}", actual_message ].compact.join(", ")
         end
 
         private
 
         attr_reader :relationship_target
-
-        def expected_message
-          "expected #{serializer_name} to use #{expected} as id_method_name for #{relationship_target}"
-        end
 
         def actual_message
           actual ? "got #{actual} instead" : nil


### PR DESCRIPTION
This PR will suppress the RSpec warnings for relationship id_method_name submatchers being used without a description.

